### PR TITLE
Provide a sensible diagnostic if a user forgets the tool

### DIFF
--- a/atbuild/src/main.swift
+++ b/atbuild/src/main.swift
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-let version = "0.6.0-dev"
+let version = "0.5.1"
 
 import Foundation
 import atpkg

--- a/atbuild/src/main.swift
+++ b/atbuild/src/main.swift
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-let version = "0.5.1"
+let version = "0.6.0-dev"
 
 import Foundation
 import atpkg

--- a/tests/fixtures/agressive/build.atpkg
+++ b/tests/fixtures/agressive/build.atpkg
@@ -1,0 +1,8 @@
+(package
+ :name "agressive"
+
+     :tasks {
+        :default {
+        }
+     }
+)

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -10,6 +10,17 @@ pwd
 echo "****************SELF-HOSTING TEST**************"
 $ATBUILD atbuild
 
+echo "****************AGRESSIVE TEST**************"
+cd $DIR/tests/fixtures/agressive
+if $ATBUILD 2&> /tmp/warnings.txt; then
+    echo "No tool specified but passed anyway?"
+    exit 1
+fi
+if ! grep "No tool for task default; did you forget to specify it?" /tmp/warnings.txt; then
+    echo "Got an error other than one prompting for the correct tool"
+    exit 1
+fi
+
 echo "****************SHADOW TEST*********************"
 cd $DIR/tests/fixtures/depend_default
 if $ATBUILD build-tests; then


### PR DESCRIPTION
Note: merge with `atpkg:agressive`

Previously, we defaulted to `atllbuild` in this case, and started
prompting them about missing atllbuild keys, e.g.

```
fatal error: Unknown outputType nil
```

This is almost certainly the wrong thing to do, instead we should
provide a diagnostic requiring them to specify the tool.

Test coverage.

Close #41
