### PR TITLE
Add `publishProduct` atllbuild option

### DIFF
--- a/attools/src/ICantBelieveItsNotFoundation.swift
+++ b/attools/src/ICantBelieveItsNotFoundation.swift
@@ -37,7 +37,7 @@ extension NSString {
 
 
 // MARK: NSFileManager.copyItemAtPath
-// https://github.com/apple/swift-corelibs-foundation/pull/248 
+// https://github.com/apple/swift-corelibs-foundation/pull/248
 enum CopyError: ErrorType {
     case CantOpenSourceFile(Int32)
     case CantOpenDestFile(Int32)
@@ -53,7 +53,13 @@ extension NSFileManager {
             throw CopyError.CantOpenSourceFile(errno)
         }
         defer { precondition(close(fd_from) >= 0) }
-        let permission = (try! attributesOfItemAtPath(srcPath)[NSFilePosixPermissions] as! NSNumber).unsignedShortValue
+        let permission_ = (try! attributesOfItemAtPath(srcPath)[NSFilePosixPermissions] as! NSNumber)
+
+        #if os(OSX) || os(iOS)
+        let permission = permission_.unsignedShortValue
+        #elseif os(Linux)
+        let permission = permission_.unsignedIntValue
+        #endif
         let fd_to = open(dstPath, O_WRONLY | O_CREAT | O_EXCL, permission)
         if fd_to < 0 {
             throw CopyError.CantOpenDestFile(errno)

--- a/attools/src/ICantBelieveItsNotFoundation.swift
+++ b/attools/src/ICantBelieveItsNotFoundation.swift
@@ -33,3 +33,52 @@ extension NSString {
         #endif
     }
 }
+
+
+
+// MARK: NSFileManager.copyItemAtPath
+// https://github.com/apple/swift-corelibs-foundation/pull/248 
+enum CopyError: ErrorType {
+    case CantOpenSourceFile(Int32)
+    case CantOpenDestFile(Int32)
+    case CantReadSourceFile(Int32)
+    case CantWriteDestFile(Int32)
+
+}
+
+extension NSFileManager {
+    func copyItemAtPath_SWIFTBUG(srcPath: String, toPath dstPath: String) throws {
+        let fd_from = open(srcPath, O_RDONLY)
+        if fd_from < 0 {
+            throw CopyError.CantOpenSourceFile(errno)
+        }
+        defer { precondition(close(fd_from) >= 0) }
+        let permission = (try! attributesOfItemAtPath(srcPath)[NSFilePosixPermissions] as! NSNumber).unsignedShortValue
+        let fd_to = open(dstPath, O_WRONLY | O_CREAT | O_EXCL, permission)
+        if fd_to < 0 {
+            throw CopyError.CantOpenDestFile(errno)
+        }
+        defer { precondition(close(fd_to) >= 0) }
+        
+        var buf = [UInt8](count: 4096, repeatedValue: 0)
+        
+        while true {
+            let nread = read(fd_from, &buf, buf.count)
+            if nread < 0 { throw CopyError.CantReadSourceFile(errno) }
+            if nread == 0 { break }
+            var writeSlice = buf[0..<nread]
+            
+            while true {
+                var nwritten: Int! = nil
+                writeSlice.withUnsafeBufferPointer({ (ptr) -> () in
+                    nwritten = write(fd_to, ptr.baseAddress, ptr.count)
+                })
+                if nwritten < 0 {
+                    throw CopyError.CantWriteDestFile(errno)
+                }
+                writeSlice = writeSlice[writeSlice.startIndex.advancedBy(nwritten)..<writeSlice.endIndex]
+                if writeSlice.count == 0 { break }
+            }
+        }
+    }
+}

--- a/attools/src/atllbuild.swift
+++ b/attools/src/atllbuild.swift
@@ -199,7 +199,9 @@ final class ATllbuild : Tool {
                             "linkWithProduct",
                             "swiftCPath",
                             "xctestify",
-                            "xctestStrict"]
+                            "xctestStrict",
+                            "publishProduct"]
+        
         for key in task.allKeys {
             if !knownOptions.contains(key) {
                 print("Warning: unknown option \(key) for task \(task.qualifiedName)")
@@ -321,5 +323,25 @@ final class ATllbuild : Tool {
         if system(cmd) != 0 {
             fatalError(cmd)
         }
+        if task["publishProduct"]?.bool == true {
+            if !manager.fileExistsAtPath("bin") {
+                try! manager.createDirectoryAtPath("bin", withIntermediateDirectories: false, attributes: nil)
+            }
+            try! copyByOverwriting("\(workDirectory)/products/\(name).swiftmodule", toPath: "bin/\(name).swiftmodule")
+            switch outputType {
+            case .Executable:
+                try! copyByOverwriting("\(workDirectory)/products/\(name)", toPath: "bin/\(name)")
+            case .StaticLibrary:
+                try! copyByOverwriting("\(workDirectory)/products/\(name).a", toPath: "bin/\(name).a")
+            }
+        }
     }
+}
+
+private func copyByOverwriting(fromPath: String, toPath: String) throws {
+    let manager = NSFileManager.defaultManager()
+    if manager.fileExistsAtPath(toPath) {
+        try manager.removeItemAtPath(toPath)
+    }
+    try! manager.copyItemAtPath(fromPath, toPath: toPath)
 }

--- a/attools/src/atllbuild.swift
+++ b/attools/src/atllbuild.swift
@@ -343,5 +343,5 @@ private func copyByOverwriting(fromPath: String, toPath: String) throws {
     if manager.fileExistsAtPath(toPath) {
         try manager.removeItemAtPath(toPath)
     }
-    try! manager.copyItemAtPath(fromPath, toPath: toPath)
+    try! manager.copyItemAtPath_SWIFTBUG(fromPath, toPath: toPath)
 }

--- a/docs/atllbuild.md
+++ b/docs/atllbuild.md
@@ -19,6 +19,9 @@ The `atllbuild` tool uses the [`swift-llbuild`](https://github.com/apple/swift-l
     ;;walk the src directory and recursively find all swift files
     :source ["src/**.swift"]
 
+    ;;if true, we publish the product to the bin/ directory.
+    :publishProduct false
+
     ;;If true, we don't build, we only output llbuild.yaml  False is the default value.
     :bootstrapOnly: false
     ;;Path to emit llbuild.yaml

--- a/tests/fixtures/publish_product/build.atpkg
+++ b/tests/fixtures/publish_product/build.atpkg
@@ -1,0 +1,24 @@
+(package
+ :name "publish_product"
+
+     :tasks {
+        :executable {
+            :tool "atllbuild"
+            :outputType "executable"
+            :name "executable"
+            :source ["main.swift"]
+            :publishProduct true
+        }
+        :library {
+            :tool "atllbuild"
+            :outputType "static-library"
+            :name "library"
+            :source ["lib.swift"]
+            :publishProduct true
+        }
+        :default {
+            :tool "nop"
+            :dependencies ["executable" "library"]
+        }
+     }
+)

--- a/tests/fixtures/publish_product/lib.swift
+++ b/tests/fixtures/publish_product/lib.swift
@@ -1,0 +1,1 @@
+class Foo { }

--- a/tests/fixtures/publish_product/main.swift
+++ b/tests/fixtures/publish_product/main.swift
@@ -1,0 +1,1 @@
+print("Hello world!")

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -10,6 +10,30 @@ pwd
 echo "****************SELF-HOSTING TEST**************"
 $ATBUILD atbuild
 
+echo "****************PUBLISHPRODUCT TEST**************"
+cd $DIR/tests/fixtures/publish_product
+$ATBUILD
+
+if [ ! -f "bin/executable" ]; then
+    echo "No executable"
+    exit 1
+fi
+
+if [ ! -f "bin/executable.swiftmodule" ]; then
+    echo "No module (executable)"
+    exit 1
+fi
+
+if [ ! -f "bin/library.swiftmodule" ]; then
+    echo "No module (library)"
+    exit 1
+fi
+
+if [ ! -f "bin/library.a" ]; then
+    echo "No library"
+    exit 1
+fi
+
 echo "****************AGRESSIVE TEST**************"
 cd $DIR/tests/fixtures/agressive
 if $ATBUILD 2&> /tmp/warnings.txt; then


### PR DESCRIPTION
This allows a build.atpkg to export its products into a user-visible directory.

I'm not totally sure this is the right design, but it does resolve #17.
