### PR TITLE
Make the "passed successfully" text green.

### DIFF
--- a/tests/test.sh
+++ b/tests/test.sh
@@ -112,4 +112,4 @@ if $ATBUILD --overlay foo; then
     exit 1
 fi
 
-echo "***ATBUILD TEST SCRIPT PASSED SUCCESSFULLY*****"
+printf "\e[1m\e[32m***ATBUILD TEST SCRIPT PASSED SUCCESSFULLY*****\e[0m"


### PR DESCRIPTION
Our swiftc frontend is typically colored, which draws attention to
various (expected) compile failures in our test suite.

To fix this, our test suite pass should report green and bold, so I stop
debugging test failures that aren't failures at all.
