### PR TITLE
Ignore tool keys when warning from atllbuild

### DIFF
--- a/attools/src/atllbuild.swift
+++ b/attools/src/atllbuild.swift
@@ -202,7 +202,6 @@ final class ATllbuild : Tool {
         
         static var allOptions : [Options] {
             return [
-                Tool,
                 Name,
                 Dependencies,
                 OutputType,
@@ -224,8 +223,12 @@ final class ATllbuild : Tool {
     func run(task: Task) {
         
         //warn if we don't understand an option
+        var knownOptions = Options.allOptions.map({$0.rawValue})
+        for option in Task.Option.allOptions.map({$0.rawValue}) {
+            knownOptions.append(option)
+        }
         for key in task.allKeys {
-            if !Options.allOptions.map({$0.rawValue}).contains(key) {
+            if !knownOptions.contains(key) {
                 print("Warning: unknown option \(key) for task \(task.qualifiedName)")
             }
         }

--- a/tests/fixtures/overlay/build.atpkg
+++ b/tests/fixtures/overlay/build.atpkg
@@ -27,7 +27,6 @@
         :sources ["src/**.swift"]
         :name "overlay"
         :output-type "static-library"
-        :germany "awesome"
         :compile-options []
       }
   }

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -64,6 +64,13 @@ if ! grep "germany" /tmp/warnings.txt; then
     exit 1
 fi
 
+cd $DIR/tests/fixtures/overlay
+$ATBUILD --use-overlay got-overlay > /tmp/warnings.txt
+if grep "Warning: " /tmp/warnings.txt; then
+    echo "Got a warning when building the overlay fixture"
+    exit 1
+fi
+
 
 echo "****************HELP TEST*********************"
 


### PR DESCRIPTION
Merge `atpkg:strong_tool` prior to merging this PR, as it's a prerequisite.

Previously, atllbuild would emit some spurious warnings when a tool key
was used such as `overlays`.  We now ignore all tool keys.
