### PR TITLE
Provide diagnostic for applied overlays

### DIFF
--- a/attools/src/TaskRunner.swift
+++ b/attools/src/TaskRunner.swift
@@ -23,7 +23,7 @@ final public class TaskRunner {
     private init() {}
 
     static public func runTask(task: Task, package: Package) {     
-        print("Running task \(task.qualifiedName)...")
+        print("Running task \(task.qualifiedName) with overlays \(task.appliedOverlays)")
         let tool = toolByName(task.tool)
         tool.run(task)
         print("Completed task \(task.qualifiedName).")


### PR DESCRIPTION
Merge with `atpkg:public_appliedoverlays`.

When we run a task, it's often useful for debugging purposes to print
what overlays were applied.
