### PR TITLE
Improve diagnostic for missing XCTest test-executable

### DIFF
--- a/attools/src/XCTestRun.swift
+++ b/attools/src/XCTestRun.swift
@@ -15,9 +15,13 @@ import atpkg
 import Foundation
 
 class XCTestRun : Tool {
+    enum Option: String {
+        case TestExecutable = "test-executable"
+    }
+
     func run(task: Task) {
-        guard let testExecutable = task["test-executable"]?.string else {
-            fatalError("No testExecutable for XCTestRun")
+        guard let testExecutable = task[Option.TestExecutable.rawValue]?.string else {
+            fatalError("No \(task[Option.TestExecutable.rawValue]) for XCTestRun")
         }
         #if os(OSX)
             var workingDirectory = "/tmp/XXXXXXXXXXX"


### PR DESCRIPTION
Was not renamed as part of the great rekeying.  Also, make this strongly
typed.
