### PR TITLE
Mute warnings

### DIFF
--- a/tests/fixtures/chained_overlays/build.atpkg
+++ b/tests/fixtures/chained_overlays/build.atpkg
@@ -1,0 +1,15 @@
+(package
+  :name "chained_overlays"
+  
+  :tasks {
+      :default {
+        :tool "nop"
+        :dependencies ["child"]
+        :overlays {
+        }
+      }
+      :child {
+        :tool "nop"
+      }
+  }
+)

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -91,12 +91,17 @@ fi
 
 cd $DIR/tests/fixtures/overlay
 $ATBUILD --use-overlay got-overlay > /tmp/warnings.txt
-if grep "Warning: " /tmp/warnings.txt; then
+if grep "Warning: Can't apply overlay no-such-overlay to task chained_overlays.child" /tmp/warnings.txt; then
     echo "Got a warning when building the overlay fixture"
     exit 1
 fi
 
-
+cd $DIR/tests/fixtures/chained_overlays
+$ATBUILD --use-overlay no-such-overlay > /tmp/warnings.txt
+if grep "Warning: Can't apply overlay no-such-overlay to task chained_overlays.child" /tmp/warnings.txt; then
+    echo "Got a warning when building the chained_overlays fixture"
+    exit 1
+fi
 
 echo "****************HELP TEST*********************"
 


### PR DESCRIPTION
Merge with `atpkg:mute_warnings`

Update for atpkg:mute_warnings, which changes the package constructor

We silence certain redundant warnings that are probably useless.
