### PR TITLE
Add proper platform support

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,12 @@ That's all you need to get started!  `atbuild` supports many more usecases than 
 
 `atbuild` supports several command-line options:
 
-* `--use-overlay [overlay]`, which you can read more about in our [overlays](overlays.html) documentation.
+* `--use-overlay [overlay]`, which you can read more about in our [overlays](http://anarchytools.org/docs/overlays.html) documentation.
 * `-f [atpkg-file]` which builds a package file other than `build.atpkg`
 * `--help`, which displays a usage message
 * `--clean`, which forces a clean build
 * `--toolchain` which specifies a nonstandard toolchain (swift installation).  By default we try to guess, but you can override our guess here.  The special string `xcode` uses "xcode swift" for building.  (Swift 2.2 does not contain all the tools we use, so you need to have a 3.x snapshot installed as well.  However, this is a "mostly" xcode-flavored buildchain.)
+* `--platform` which specifies the target platform.  By default, this is the current platform.  Pass a different value (`osx` or `linux`) to cross-compile, only if your compiler supports it.
 
 # Building
 

--- a/atbuild/src/main.swift
+++ b/atbuild/src/main.swift
@@ -27,24 +27,25 @@ enum Options: String {
     case Help = "--help"
     case Clean = "--clean"
     case Toolchain = "--toolchain"
-
-    static var allOptions : [Options] { return [Overlay, CustomFile, Help, Clean, Toolchain] }
+    case Platform = "--platform"
+    
+    static var allOptions : [Options] { return [
+        Overlay, 
+        CustomFile, 
+        Help, 
+        Clean, 
+        Toolchain, 
+        Platform
+        ] 
+    }
 }
 
 let defaultPackageFile = "build.atpkg"
 
 var focusOnTask : String? = nil
 
-//build overlays
-var overlays : [String] = []
-for (i, x) in Process.arguments.enumerated() {
-    if x == Options.Overlay.rawValue {
-        let overlay = Process.arguments[i+1]
-        overlays.append(overlay)
-    }
-}
 var packageFile = defaultPackageFile
-var toolchain = DefaultToolchainPath
+var toolchain = Platform.buildPlatform.defaultToolchainPath
 for (i, x) in Process.arguments.enumerated() {
     if x == Options.CustomFile.rawValue {
         packageFile = Process.arguments[i+1]
@@ -55,7 +56,24 @@ for (i, x) in Process.arguments.enumerated() {
             toolchain = "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain"
         }
     }
+    if x == Options.Platform.rawValue {
+        let platformString = Process.arguments[i+1]
+        Platform.targetPlatform = Platform(string: platformString)
+    }
 }
+
+//build overlays
+var overlays : [String] = []
+for (i, x) in Process.arguments.enumerated() {
+    if x == Options.Overlay.rawValue {
+        let overlay = Process.arguments[i+1]
+        overlays.append(overlay)
+    }
+}
+overlays.append(contentsOf: Platform.targetPlatform.overlays)
+
+print("enabling overlays \(overlays)")
+
 let package = try! Package(filepath: packageFile, overlay: overlays, focusOnTask: focusOnTask)
 
 //usage message

--- a/attools/src/ICantBelieveItsNotFoundation.swift
+++ b/attools/src/ICantBelieveItsNotFoundation.swift
@@ -102,7 +102,19 @@ extension String {
     func replacingOccurrences(of str: String, with: String) -> String {
         return self.stringByReplacingOccurrencesOfString(str, withString: with)
     }
+    func cString(usingEncoding encoding: NSStringEncoding) -> [CChar]? {
+        return self.cStringUsingEncoding(encoding)
+    }
+    init?(cString: UnsafePointer<CChar>, encoding: NSStringEncoding) {
+        precondition(encoding == NSUTF8StringEncoding)
+        self.init(validatingUTF8: cString)
+    }
+
+    func cString(using: NSStringEncoding) -> [CChar]? {
+        return self.cString(usingEncoding: using)
+    }
 }
+
 #endif
 
 //These parts are possibly? not yet implemented on OSX

--- a/attools/src/PackageFramework.swift
+++ b/attools/src/PackageFramework.swift
@@ -68,7 +68,7 @@ class PackageFramework: Tool {
         try! manager.createSymbolicLink(atPath: "\(frameworkPath)/Versions/Current", withDestinationPath: "A")
 
         //copy payload
-        let payloadPath = task.importedPath + "bin/" + name + DynamicLibraryExtension
+        let payloadPath = task.importedPath + "bin/" + name + Platform.targetPlatform.dynamicLibraryExtension
         print(payloadPath)
         try! manager.copyItemAtPath_SWIFTBUG(srcPath: payloadPath, toPath: "\(AVersionPath)/\(name)")
         try! manager.createSymbolicLink(atPath: "\(frameworkPath)/\(name)", withDestinationPath: "\(relativeAVersionPath)/\(name)")
@@ -76,8 +76,8 @@ class PackageFramework: Tool {
         //copy modules
         let modulePath = "\(AVersionPath)/Modules/\(name).swiftmodule"
         try! manager.createDirectory(atPath: modulePath, withIntermediateDirectories: true, attributes: nil)
-        try! manager.copyItemAtPath_SWIFTBUG(srcPath: "bin/\(name).swiftmodule", toPath: "\(modulePath)/\(Architecture).swiftmodule")
-        try! manager.copyItemAtPath_SWIFTBUG(srcPath: "bin/\(name).swiftdoc", toPath: "\(modulePath)/\(Architecture).swiftdoc")
+        try! manager.copyItemAtPath_SWIFTBUG(srcPath: "bin/\(name).swiftmodule", toPath: "\(modulePath)/\(Platform.targetPlatform.architecture).swiftmodule")
+        try! manager.copyItemAtPath_SWIFTBUG(srcPath: "bin/\(name).swiftdoc", toPath: "\(modulePath)/\(Platform.targetPlatform.architecture).swiftdoc")
         try! manager.createSymbolicLink(atPath: "\(frameworkPath)/Modules", withDestinationPath: "\(relativeAVersionPath)/Modules")
 
         //copy resources

--- a/attools/src/XCTestRun.swift
+++ b/attools/src/XCTestRun.swift
@@ -23,7 +23,8 @@ class XCTestRun : Tool {
         guard let testExecutable = task[Option.TestExecutable.rawValue]?.string else {
             fatalError("No \(Option.TestExecutable.rawValue) for XCTestRun task \(task.qualifiedName)")
         }
-        #if os(OSX)
+        switch (Platform.targetPlatform) {
+            case .OSX:
             var workingDirectory = "/tmp/XXXXXXXXXXX"
             var template = workingDirectory.cString(using: NSUTF8StringEncoding)!
             workingDirectory = String(cString: mkdtemp(&template), encoding: NSUTF8StringEncoding)!
@@ -66,12 +67,10 @@ class XCTestRun : Tool {
                 fatalError("Test execution failed.")
             }
 
-        #elseif os(Linux)
+            case .Linux:
             if system("\(testExecutable)") != 0 {
                 fatalError("Test execution failed.")
             }
-        #else
-            fatalError("Not implemented")
-        #endif
+        }
     }
 }

--- a/tests/fixtures/platforms/build.atpkg
+++ b/tests/fixtures/platforms/build.atpkg
@@ -1,0 +1,45 @@
+;; Copyright (c) 2016 Anarchy Tools Contributors.
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;   http:;;www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(package
+  :name "platforms"
+  
+  :tasks {
+    :build {
+      :tool "atllbuild"
+      :sources ["main.swift"]
+      :name "platforms"
+      :output-type "executable"
+      :publish-product true
+      :overlays {
+        :atbuild.platform.osx {
+          :compile-options ["-D" "OSX"]
+        }
+        :atbuild.platform.linux {
+          :compile-options ["-D" "LINUX"]
+        }
+        :bootstrap-only {
+           :bootstrap-only true
+           :llbuildyaml "bin/bootstrap-platform.yaml"
+        }
+      }
+     }
+     :check {
+      :dependencies ["build"]
+      :tool "shell"
+      :script "bin/platforms"
+     }
+  }
+
+)

--- a/tests/fixtures/platforms/known-linux-bootstrap.yaml
+++ b/tests/fixtures/platforms/known-linux-bootstrap.yaml
@@ -1,0 +1,26 @@
+client:
+  name: swift-build
+
+tools: {}
+
+targets:
+  "": [<atllbuild>]
+  atllbuild: [<atllbuild>]
+commands:
+  <atllbuild-swiftc>:
+     tool: swift-compiler
+     executable: "//usr/local/bin/swiftc"
+     inputs: ["main.swift"]
+     sources: ["main.swift"]
+     objects: [".atllbuild/objects/main.swift.o"]
+     outputs: ["<atllbuild-swiftc>", ".atllbuild/objects/main.swift.o"]
+     module-name: platforms
+     module-output-path: .atllbuild/products/platforms.swiftmodule
+     temps-path: .atllbuild//llbuildtmp
+     other-args: ["-j8", "-D", "ATBUILD", "-I", ".atllbuild/products/", "-D", "LINUX"]
+  <atllbuild>:
+    tool: shell
+    inputs: ["<atllbuild-swiftc>", ".atllbuild/objects/main.swift.o"]
+    outputs: ["<atllbuild>", ".atllbuild/products/platforms"]
+    args: ["//usr/local/bin/swiftc", "-o", ".atllbuild/products/platforms", ".atllbuild/objects/main.swift.o"]
+    description: Linking executable .atllbuild/products/platforms

--- a/tests/fixtures/platforms/known-osx-bootstrap.yaml
+++ b/tests/fixtures/platforms/known-osx-bootstrap.yaml
@@ -1,0 +1,26 @@
+client:
+  name: swift-build
+
+tools: {}
+
+targets:
+  "": [<atllbuild>]
+  atllbuild: [<atllbuild>]
+commands:
+  <atllbuild-swiftc>:
+     tool: swift-compiler
+     executable: "/Library/Developer/Toolchains/swift-latest.xctoolchain/usr/bin/swiftc"
+     inputs: ["main.swift"]
+     sources: ["main.swift"]
+     objects: [".atllbuild/objects/main.swift.o"]
+     outputs: ["<atllbuild-swiftc>", ".atllbuild/objects/main.swift.o"]
+     module-name: platforms
+     module-output-path: .atllbuild/products/platforms.swiftmodule
+     temps-path: .atllbuild//llbuildtmp
+     other-args: ["-j8", "-D", "ATBUILD", "-I", ".atllbuild/products/", "-sdk", "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk", "-D", "OSX"]
+  <atllbuild>:
+    tool: shell
+    inputs: ["<atllbuild-swiftc>", ".atllbuild/objects/main.swift.o"]
+    outputs: ["<atllbuild>", ".atllbuild/products/platforms"]
+    args: ["/Library/Developer/Toolchains/swift-latest.xctoolchain/usr/bin/swiftc", "-o", ".atllbuild/products/platforms", ".atllbuild/objects/main.swift.o"]
+    description: Linking executable .atllbuild/products/platforms

--- a/tests/fixtures/platforms/main.swift
+++ b/tests/fixtures/platforms/main.swift
@@ -1,0 +1,5 @@
+#if OSX
+print("Hello from OSX!")
+#elseif LINUX
+print("Hello from LINUX!")
+#endif

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -10,6 +10,36 @@ pwd
 echo "****************SELF-HOSTING TEST**************"
 $ATBUILD atbuild
 
+echo "****************PLATFORMS TEST**************"
+cd $DIR/tests/fixtures/platforms
+UNAME=`uname`
+$ATBUILD check 2&> /tmp/platforms.txt
+if [ "$UNAME" == "Darwin" ]; then
+    STR="Hello from OSX!"
+else
+    STR="Hello from LINUX!"
+fi
+if ! grep "$STR" /tmp/platforms.txt; then
+    cat /tmp/platforms.txt
+    echo "Did not find platform print in platform test"
+    exit 1
+fi
+
+#check bootstrapping case
+$ATBUILD build --use-overlay bootstrap-only --platform linux
+if ! cmp --silent bin/bootstrap-platform.yaml known-linux-bootstrap.yaml; then
+    echo "Linux bootstrap was unexpected"
+    exit 1
+fi
+
+$ATBUILD build --use-overlay bootstrap-only --platform osx
+if ! cmp --silent bin/bootstrap-platform.yaml known-osx-bootstrap.yaml; then
+    echo "OSX bootstrap was unexpected"
+    exit 1
+fi
+
+
+
 echo "****************XCODE TOOLCHAIN TEST**************"
 
 if [ -e "/Applications/Xcode.app" ]; then


### PR DESCRIPTION
Related to #36

Presently, we tend to enable platform-specific config with an overlay.
There are a variety of problems identified with this approach:
1.  There is no convention for which overlay to use for platform-
   specific config.  This complicates the ecosystem.
2.  In general, a program is always compiled "for some platform" but in
   practice a user may forget the necessary overlay.  `require-overlays`
   can catch this misconfig, but A) it has to be opted into in the atpkg,
   and B) there is no good way to default to the running platform, which is
   the sane behavior.
3.  Currently, tools tend to conditionally-compile platform-specific
   code.  The effect of this is to complicate bootstrapping, as a Linux
   binary _cannot_ perform some OSX behavior (and vice versa) because the
   necessary code is not present in the executable.
4.  This is not scaleable to cross-compilation (iOS for example is
   Coming Soon™ but can't be supported in this architecture)

To work around these problems, we introduce a `Platform` enum, to
replace `PlatformPaths`.  `Platform` is a runtime technology, allowing
for a Linux binary to reason about what the behavior would be on OSX
etc.

Internally, we have three "platforms":
- `hostPlatform`, the platform on which `atbuild` is currently executing
- `targetPlatform`, the platform for which we are compiling. By default
  this is the `hostPlatform`
- `buildPlatform`, the platform where `swift-build-tool` will run.
  This is usually the `hostPlatform`, but if we are bootstrapping it
  is the `targetPlatform` instead.

The user can override the `targetPlatform` by the use of `--platform
foo`.  `linux` and `osx` are supported.  `mac` is supported as an alias
of `osx`.

The primary effect of a platform is to scope tool-specific behavior
(e.g., target=OSX uses the OSX SDK, host=Linux uses a linux path for the
toolchain, etc).

In addition to the tool-specific behavior, we enable overlays for the
target platform:
- `atbuild.platform.linux` on Linux
- `atbuild.platform.osx` and `atbuild.platform.mac` on OSX

This allows packages to reliably perform per-platform configuration in
the overlays.  Critically, some platform overlay is reliably active, so
users in most cases will not have to `--use-overlay` to get proper
platform behavior.

DEPRECATION WARNING: We believe the `swiftc-path` key is no longer
required, as the functionality used can be achieved either by
`--toolchain` or `--platform`.  Therefore, I'm adding a warning to users
that we intend to remove it and to try these features instead.

We need to put out a release with these features (and the warning)
before I'm happy to remove it.  In particular, we use it inside
atbuild/atpkg, and removing it immediately would break bootstrapping, so
let's give it a little time before we tear it out.  We should remove it
from the documentation though.
