### PR TITLE
Don't print stack trace for user-visible subcommand errors

### DIFF
--- a/attools/src/Shell.swift
+++ b/attools/src/Shell.swift
@@ -31,10 +31,8 @@ final class Shell : Tool {
             defer { NSFileManager.defaultManager().changeCurrentDirectoryPath(oldPath) }
 
             NSFileManager.defaultManager().changeCurrentDirectoryPath(task.importedPath)
-
-            if system("/bin/sh -c \"\(script)\"") != 0 {
-                fatalError("/bin/sh -c \(script)")
-            }
+            
+            anarchySystem("/bin/sh -c \"\(script)\"")
         }
     }
 }

--- a/attools/src/Tools.swift
+++ b/attools/src/Tools.swift
@@ -55,3 +55,16 @@ func userPath() -> String {
     }
     return userPath
 }
+
+///A wrapper for POSIX "system" call.
+///If return value is non-zero, we exit (not fatalError)
+///See #72 for details.
+///- note: This function call is appropriate for commands that are user-perceivable (such as compilation)
+///Rather than calls that aren't
+func anarchySystem(_ cmd: String) {
+    let returnCode = system(cmd)
+    if returnCode != 0 {
+        print("\(cmd) exited with return code \(returnCode)")
+        exit(42)
+    }
+}

--- a/attools/src/XCTestRun.swift
+++ b/attools/src/XCTestRun.swift
@@ -62,14 +62,10 @@ class XCTestRun : Tool {
             s += "</dict>\n"
             s += "</plist>\n"
             try! s.write(toFile: workingDirectory + "/XCTestRun.xctest/Contents/Info.plist", atomically: false, encoding: NSUTF8StringEncoding)
-            if system("xcrun xctest \(workingDirectory)/XCTestRun.xctest") != 0 {
-                fatalError("Test execution failed.")
-            }
+            anarchySystem("xcrun xctest \(workingDirectory)/XCTestRun.xctest")
 
         #elseif os(Linux)
-            if system("\(testExecutable)") != 0 {
-                fatalError("Test execution failed.")
-            }
+            anarchySystem("\(testExecutable)")
         #else
             fatalError("Not implemented")
         #endif

--- a/attools/src/atllbuild.swift
+++ b/attools/src/atllbuild.swift
@@ -445,9 +445,7 @@ final class ATllbuild : Tool {
 
         //SR-566
         let cmd = "\(findToolPath(toolName: "swift-build-tool",toolchain: toolchain)) -f \(llbuildyamlpath)"
-        if system(cmd) != 0 {
-            fatalError(cmd)
-        }
+        anarchySystem(cmd)
         if task[Options.PublishProduct.rawValue]?.bool == true {
             if !manager.fileExists(atPath: "bin") {
                 try! manager.createDirectory(atPath: "bin", withIntermediateDirectories: false, attributes: nil)


### PR DESCRIPTION
Per #72, these are not useful

Resolve #72
