### PR TITLE
Add iOS support

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,14 +10,14 @@ linux:
         - git submodule update --init --recursive
         - bootstrap/build.sh linux
         - tests/test.sh
-        - mkdir atbuild-${CI_BUILD_REF_NAME}
-        - cp bin/atbuild atbuild-${CI_BUILD_REF_NAME}
-        - tar cJf atbuild-${CI_BUILD_REF_NAME}-linux.tar.xz atbuild-${CI_BUILD_REF_NAME}
+        - mkdir atbuild-${CI_BUILD_REF}
+        - cp bin/atbuild atbuild-${CI_BUILD_REF}
+        - tar cJf atbuild-${CI_BUILD_REF}-linux.tar.xz atbuild-${CI_BUILD_REF}
     tags:
         - autoscale-linux
     artifacts:
         paths:
-            - atbuild-${CI_BUILD_REF_NAME}-linux.tar.xz
+            - atbuild-${CI_BUILD_REF}-linux.tar.xz
     image: drewcrawford/swift:latest
 
 osx:
@@ -27,11 +27,11 @@ osx:
         - export PATH=/Library/Developer/Toolchains/swift-latest.xctoolchain/usr/bin:"${PATH}"
         - ./bootstrap/build.sh
         - bin/atbuild check
-        - mkdir atbuild-${CI_BUILD_REF_NAME}
-        - cp bin/atbuild atbuild-${CI_BUILD_REF_NAME}
-        - tar cJf atbuild-${CI_BUILD_REF_NAME}-osx.tar.xz atbuild-${CI_BUILD_REF_NAME}
+        - mkdir atbuild-${CI_BUILD_REF}
+        - cp bin/atbuild atbuild-${CI_BUILD_REF}
+        - tar cJf atbuild-${CI_BUILD_REF}-osx.tar.xz atbuild-${CI_BUILD_REF}
     tags:
         - openswift
     artifacts:
         paths:
-            - atbuild-${CI_BUILD_REF_NAME}-osx.tar.xz
+            - atbuild-${CI_BUILD_REF}-osx.tar.xz

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ That's all you need to get started!  `atbuild` supports many more usecases than 
 * `--help`, which displays a usage message
 * `--clean`, which forces a clean build
 * `--toolchain` which specifies a nonstandard toolchain (swift installation).  By default we try to guess, but you can override our guess here.  The special string `xcode` uses "xcode swift" for building.  (Swift 2.2 does not contain all the tools we use, so you need to have a 3.x snapshot installed as well.  However, this is a "mostly" xcode-flavored buildchain.)
-* `--platform` which specifies the target platform.  By default, this is the current platform.  Pass a different value (`osx` or `linux`) to cross-compile, only if your compiler supports it.
+* `--platform` which specifies the target platform.  By default, this is the current platform.  Pass a different value (`osx`, `linux`, `ios-x86_64`, `ios-i386`, `ios-arm64`, or `ios-armv7`) to cross-compile, only if your compiler supports it.
 
 # Building
 

--- a/attools/src/PackageFramework.swift
+++ b/attools/src/PackageFramework.swift
@@ -82,8 +82,8 @@ class PackageFramework: Tool {
         //copy modules
         let modulePath = AVersionPath.appending("Modules").appending(name + ".swiftmodule")
         try! FS.createDirectory(path: modulePath, intermediate: true)
-        try! FS.copyItem(from: Path("bin/\(name).swiftmodule"), to: modulePath.appending(Platform.targetPlatform.architecture + ".swiftmodule"))
-        try! FS.copyItem(from: Path("bin/\(name).swiftdoc"), to: modulePath.appending(Platform.targetPlatform.architecture + ".swiftdoc"))
+        try! FS.copyItem(from: Path("bin/\(name).swiftmodule"), to: modulePath.appending(Platform.targetPlatform.architecture.description + ".swiftmodule"))
+        try! FS.copyItem(from: Path("bin/\(name).swiftdoc"), to: modulePath.appending(Platform.targetPlatform.architecture.description + ".swiftdoc"))
         try! FS.symlinkItem(from: relativeAVersionPath.appending("Modules"), to: frameworkPath.appending("Modules"))
 
         //copy resources

--- a/attools/src/PlatformPaths.swift
+++ b/attools/src/PlatformPaths.swift
@@ -21,6 +21,24 @@ public enum Architecture {
     case arm64
 }
 
+extension Architecture: CustomStringConvertible {
+    public var description: String {
+        switch(self) {
+            case .x86_64:
+            return "x86_64"
+
+            case .i386:
+            return "i386"
+
+            case .armv7:
+            return "armv7"
+
+            case .arm64:
+            return "arm64"
+        }
+    }
+}
+
 func ==(a: Platform, b: Platform) -> Bool {
     switch(a, b) {
         case (.OSX, .OSX): return true

--- a/attools/src/XCTestRun.swift
+++ b/attools/src/XCTestRun.swift
@@ -68,6 +68,9 @@ class XCTestRun : Tool {
             }
             case .Linux:
             anarchySystem("\(testExecutable)")
+
+			case .iOS:
+            fatalError("XCTestRun is not supported for iOS")
         }
     }
 }

--- a/attools/src/atllbuild.swift
+++ b/attools/src/atllbuild.swift
@@ -362,6 +362,9 @@ final class ATllbuild : Tool {
 
                 case .Linux:
                 break
+
+                case .iOS:
+                fatalError("\(Options.XCTestify.rawValue) is not supported for iOS")
             }
         }
         if task[Options.XCTestStrict.rawValue]?.bool == true {
@@ -384,6 +387,9 @@ final class ATllbuild : Tool {
 
             case .Linux:
                 break
+
+                case .iOS:
+                fatalError("\(Options.XCTestStrict.rawValue) is not supported for iOS")
             }
         }
         let moduleMap: ModuleMapType
@@ -418,6 +424,32 @@ final class ATllbuild : Tool {
             compileOptions.append("-I")
             compileOptions.append(workDirectory.appending("include").description + "/")
             compileOptions.append("-import-underlying-module")
+        }
+
+        //inject target
+        switch(Platform.targetPlatform) {
+            case .iOS(let arch):
+            switch(arch) {
+                case .x86_64:
+                compileOptions.append(contentsOf: ["-target","x86_64-apple-ios9.3"])
+                linkOptions.append(contentsOf: ["-target","x86_64-apple-ios9.3"])
+
+                case .i386:
+                compileOptions.append(contentsOf: ["-target","i386-apple-ios9.3"])
+                linkOptions.append(contentsOf: ["-target","i386-apple-ios9.3"])
+
+                case .arm64:
+                compileOptions.append(contentsOf: ["-target","arm64-apple-ios9.3"])
+                linkOptions.append(contentsOf: ["-target","arm64-apple-ios9.3"])
+
+                case .armv7:
+                compileOptions.append(contentsOf: ["-target","armv7-apple-ios9.3"])
+                linkOptions.append(contentsOf: ["-target","armv7-apple-ios9.3"])
+
+            }
+            linkOptions.append(contentsOf: ["-Xlinker", "-syslibroot","-Xlinker",Platform.targetPlatform.sdkPath!])
+            case .OSX, .Linux:
+                break //not required
         }
 
         let bootstrapOnly: Bool

--- a/tests/fixtures/ios/build.atpkg
+++ b/tests/fixtures/ios/build.atpkg
@@ -1,0 +1,47 @@
+;; Copyright (c) 2016 Anarchy Tools Contributors.
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;   http:;;www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(package
+  :name "ios"
+  
+  :tasks {
+      :static {
+        :tool "atllbuild"
+        :sources ["src/**.swift"]
+        :name "static"
+        :output-type "static-library"
+        :compile-options []
+      }
+      :dynamic {
+        :tool "atllbuild"
+        :sources ["src/**.swift"]
+        :name "dynamic"
+        :output-type "dynamic-library"
+        :compile-options []
+      }
+
+      :executable {
+        :tool "atllbuild"
+        :sources ["src/**.swift"]
+        :name "executable"
+        :output-type "executable"
+        :compile-options []
+      }
+
+      :default {
+        :tool "nop"
+        :dependencies ["static" "dynamic" "executable"]
+      }
+  }
+)

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -23,6 +23,87 @@ if ! grep "\-key value --test test_substitution --userpath .*tests/fixtures/atto
     exit 1
 fi
 
+echo "****************IOS TEST**************"
+cd $DIR/tests/fixtures/ios
+UNAME=`uname`
+if [ "$UNAME" == "Darwin" ]; then
+    $ATBUILD --platform ios-x86_64 ##FIXME
+    INFO=`lipo -info .atllbuild/products/static.a`
+    if [[ "$INFO" != *"architecture: x86_64"* ]]; then
+        echo "bad architecture $INFO"
+        exit 1
+    fi
+    INFO=`lipo -info .atllbuild/products/dynamic.dylib`
+    if [[ "$INFO" != *"architecture: x86_64"* ]]; then
+        echo "bad architecture $INFO"
+        exit 1
+    fi
+
+    INFO=`lipo -info .atllbuild/products/executable`
+    if [[ "$INFO" != *"architecture: x86_64"* ]]; then
+        echo "bad architecture $INFO"
+        exit 1
+    fi
+
+
+    $ATBUILD --platform ios-i386
+    INFO=`lipo -info .atllbuild/products/static.a`
+    if [[ "$INFO" != *"architecture: i386"* ]]; then
+        echo "bad architecture $INFO"
+        exit 1
+    fi
+    INFO=`lipo -info .atllbuild/products/dynamic.dylib`
+    if [[ "$INFO" != *"architecture: i386"* ]]; then
+        echo "bad architecture $INFO"
+        exit 1
+    fi
+
+    INFO=`lipo -info .atllbuild/products/executable`
+    if [[ "$INFO" != *"architecture: i386"* ]]; then
+        echo "bad architecture $INFO"
+        exit 1
+    fi
+
+    $ATBUILD --platform ios-arm64
+    INFO=`lipo -info .atllbuild/products/static.a`
+    if [[ "$INFO" != *"architecture: arm64"* ]]; then
+        echo "bad architecture $INFO"
+        exit 1
+    fi
+    INFO=`lipo -info .atllbuild/products/dynamic.dylib`
+    if [[ "$INFO" != *"architecture: arm64"* ]]; then
+        echo "bad architecture $INFO"
+        exit 1
+    fi
+
+    INFO=`lipo -info .atllbuild/products/executable`
+    if [[ "$INFO" != *"architecture: arm64"* ]]; then
+        echo "bad architecture $INFO"
+        exit 1
+    fi
+
+    $ATBUILD --platform ios-armv7
+    INFO=`lipo -info .atllbuild/products/static.a`
+    if [[ "$INFO" != *"architecture: armv7"* ]]; then
+        echo "bad architecture $INFO"
+        exit 1
+    fi
+    INFO=`lipo -info .atllbuild/products/dynamic.dylib`
+    if [[ "$INFO" != *"architecture: armv7"* ]]; then
+        echo "bad architecture $INFO"
+        exit 1
+    fi
+
+    INFO=`lipo -info .atllbuild/products/executable`
+    if [[ "$INFO" != *"architecture: armv7"* ]]; then
+        echo "bad architecture $INFO"
+        exit 1
+    fi
+
+else
+    echo "Skipping iOS tests on non-Darwin platform"
+fi
+
 echo "****************PLATFORMS TEST**************"
 cd $DIR/tests/fixtures/platforms
 UNAME=`uname`


### PR DESCRIPTION
![7drhiqr](https://cloud.githubusercontent.com/assets/183400/14595174/bd05319a-0502-11e6-97bd-bceb51eba02f.gif)

This commit adds support for static libraries, dynamic libraries, and
executables compiled for iOS.

FAQ:

Q: How do I build them?

Use the new `--platform` strings:
- `ios-x86_64`
- `ios-i386`
- `ios-arm64`
- `ios-armv7`

Q: What if I want to build for more than one architecture?

Coming Soon™

Q: What is an iOS "executable", anyway?

No idea, but it works!

Q: What is not yet supported?
- [ ] XCTest
- [ ] Deploying or running iOS build products
- [ ] Frameworks
- [ ] Code signing
- [ ] Compiling for iOS on Linux.  Believe it or not, I think this
    is actually possible for some programs, but I have no use for it
