### PR TITLE
Export ATBUILD_PLATFORM

### DIFF
--- a/attools/src/CustomTool.swift
+++ b/attools/src/CustomTool.swift
@@ -25,6 +25,7 @@ final class CustomTool: Tool {
             cmd += "--\(key) \"\(evaluateSubstitutions(input: value, package: task.package))\" "
         }
         setenv("ATBUILD_USER_PATH", userPath().description, 1)
+        setenv("ATBUILD_PLATFORM", "\(Platform.targetPlatform)", 1)
         anarchySystem(cmd)
     }
 }

--- a/attools/src/PlatformPaths.swift
+++ b/attools/src/PlatformPaths.swift
@@ -155,6 +155,19 @@ public enum Platform {
     public static var buildPlatform: Platform = Platform.hostPlatform
 }
 
+extension Platform: CustomStringConvertible {
+    public var description: String {
+        switch(self) {
+            case .OSX:
+            return "osx"
+            case .Linux:
+            return "linux"
+            case .iOS(let architecture):
+            return "ios-\(architecture)"
+        }
+    }
+}
+
 func findToolPath(toolName: String, toolchain: String) -> Path {
 
     if Platform.buildPlatform == Platform.hostPlatform {

--- a/attools/src/Shell.swift
+++ b/attools/src/Shell.swift
@@ -28,6 +28,7 @@ import atpkg
  */
 final class Shell : Tool {
     func run(task: Task, toolchain: String) {
+        setenv("ATBUILD_PLATFORM", "\(Platform.targetPlatform)", 1)
         setenv("ATBUILD_USER_PATH", userPath().description, 1)
         guard var script = task["script"]?.string else { fatalError("Invalid 'script' argument to shell tool.") }
         script = evaluateSubstitutions(input: script, package: task.package)

--- a/tests/fixtures/attool/build.atpkg
+++ b/tests/fixtures/attool/build.atpkg
@@ -22,8 +22,9 @@
       :key "value"
       :test "${test_substitution}"
       :userpath "\${ATBUILD_USER_PATH}"
+      :platform "\${ATBUILD_PLATFORM}"
       :dependencies ["a"]
+    }
   }
-}
 
 )

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 set -e
+UNAME=`uname`
+
 
 echo "**********THE ATBUILD TEST SCRIPT*************"
 
@@ -17,15 +19,21 @@ fi
 echo "****************PLUGIN TEST**************"
 cd $DIR/tests/fixtures/attool
 $ATBUILD > /tmp/plugin.txt
-if ! grep "\-key value --test test_substitution --userpath .*tests/fixtures/attool/user" /tmp/plugin.txt; then
+if [ "$UNAME" == "Darwin" ]; then
+    SEARCHTEXT="\-key value --platform osx --test test_substitution --userpath .*tests/fixtures/attool/user"
+else
+    SEARCHTEXT="\-key value --platform linux --test test_substitution --userpath .*tests/fixtures/attool/user"
+fi
+
+if ! grep "$SEARCHTEXT" /tmp/plugin.txt; then
     cat /tmp/plugin.txt
     echo "Did not find key print in plugin test"
+    echo $SEARCHTEXT
     exit 1
 fi
 
 echo "****************IOS TEST**************"
 cd $DIR/tests/fixtures/ios
-UNAME=`uname`
 if [ "$UNAME" == "Darwin" ]; then
     $ATBUILD --platform ios-x86_64 ##FIXME
     INFO=`lipo -info .atllbuild/products/static.a`


### PR DESCRIPTION
ATBUILD_PLATFORM is now exported to custom tools and shell scripts.

This allows external tools to know atbuild's target platform.
