### PR TITLE
Add executable-name option to atllbuild

### DIFF
--- a/tests/fixtures/executable_name/build.atpkg
+++ b/tests/fixtures/executable_name/build.atpkg
@@ -1,0 +1,20 @@
+(package
+    :name "executable_name"
+
+    :tasks {
+        :default {
+            :tool "atllbuild"
+            :name "executable_name"
+            :executable-name "executable-name"
+            :sources ["src/**.swift"]
+            :publish-product true
+            :output-type "executable"
+        }
+        :check {
+            :tool "shell"
+            :script "bin/executable-name"
+            :dependencies ["default"]
+        }
+    }
+
+)

--- a/tests/fixtures/executable_name/src/main.swift
+++ b/tests/fixtures/executable_name/src/main.swift
@@ -1,0 +1,1 @@
+print("Hello world")

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -16,6 +16,10 @@ if ! $ATBUILD atbuild --use-overlay static; then
     $ATBUILD atbuild
 fi
 
+echo "****************EXECUTABLE-NAME TEST**************"
+cd $DIR/tests/fixtures/executable_name
+$ATBUILD check
+
 echo "****************ATBIN TEST**************"
 cd $DIR/tests/fixtures/atbin
 


### PR DESCRIPTION
We add an executable-name option to atllbuild, allowing the use of "non-module-safe" names for executables.  This includes e.g. hyphens, which are a legal executable name but not a legal module-name.

Resolve #27.  This resolution was chosen (over name/module-name) because the module-name is used in several places (such as Frameworks for example) and the executable case seems to be the odd one out at present.
