### PR TITLE
Add ATBUILD_BIN_PATH

### DIFF
--- a/attools/src/CustomTool.swift
+++ b/attools/src/CustomTool.swift
@@ -24,12 +24,8 @@ final class CustomTool: Tool {
             }
             cmd += "--\(key) \"\(evaluateSubstitutions(input: value, package: task.package))\" "
         }
-        setenv("ATBUILD_USER_PATH", userPath().description, 1)
-        setenv("ATBUILD_PLATFORM", "\(Platform.targetPlatform)", 1)
-        if let version = task.package.version {
-            setenv("ATBUILD_PACKAGE_VERSION", version, 1)
+        Shell.environvironment(task: task) {
+            anarchySystem(cmd)
         }
-        
-        anarchySystem(cmd)
     }
 }

--- a/tests/fixtures/attool/build.atpkg
+++ b/tests/fixtures/attool/build.atpkg
@@ -25,6 +25,7 @@
       :userpath "\${ATBUILD_USER_PATH}"
       :platform "\${ATBUILD_PLATFORM}"
       :version "\${ATBUILD_PACKAGE_VERSION}"
+      :bindir "\${ATBUILD_BIN_PATH}"
       :dependencies ["a"]
     }
   }

--- a/tests/fixtures/user_paths/b/build.atpkg
+++ b/tests/fixtures/user_paths/b/build.atpkg
@@ -4,7 +4,7 @@
      :tasks {
         :second {
             :tool "shell"
-            :script "echo SECOND >> $ATBUILD_USER_PATH/test"
+            :script "echo SECOND >> $ATBUILD_USER_PATH/test && echo SECOND >> $ATBUILD_BIN_PATH/test"
         }
      }
 )

--- a/tests/fixtures/user_paths/build.atpkg
+++ b/tests/fixtures/user_paths/build.atpkg
@@ -5,11 +5,12 @@
      :tasks {
         :first {
             :tool "shell"
-            :script "echo FIRST >> $ATBUILD_USER_PATH/test"
+            ;; note that binpath is not recreated, therefore we use single > here to force a new file
+            :script "echo FIRST >> $ATBUILD_USER_PATH/test && echo FIRST > $ATBUILD_BIN_PATH/test"
         }
         :third {
             :tool "shell"
-            :script "echo THIRD >> $ATBUILD_USER_PATH/test"
+            :script "echo THIRD >> $ATBUILD_USER_PATH/test && echo THIRD >> $ATBUILD_BIN_PATH/test"
             :dependencies ["first" "b.second"]
         }
         :compiledep {

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -196,9 +196,9 @@ echo "****************PLUGIN TEST**************"
 cd $DIR/tests/fixtures/attool
 $ATBUILD > /tmp/plugin.txt
 if [ "$UNAME" == "Darwin" ]; then
-    SEARCHTEXT="\-key value --platform osx --test test_substitution --userpath .*tests/fixtures/attool/user --version 1.0"
+    SEARCHTEXT="\-bindir .*tests/fixtures/attool/bin --key value --platform osx --test test_substitution --userpath .*tests/fixtures/attool/user --version 1.0"
 else
-    SEARCHTEXT="\-key value --platform linux --test test_substitution --userpath .*tests/fixtures/attool/user --version 1.0"
+    SEARCHTEXT="\-bindir .*tests/fixtures/attool/bin --key value --platform linux --test test_substitution --userpath .*tests/fixtures/attool/user --version 1.0"
 fi
 
 if ! grep "$SEARCHTEXT" /tmp/plugin.txt; then
@@ -367,6 +367,11 @@ SECOND
 THIRD"
 if [ "$RESULT" != "$RESULT2" ]; then
     echo "Unusual user path concoction $RESULT $RESULT2"
+    exit 1
+fi
+RESULT=`cat bin/test`
+if [ "$RESULT" != "$RESULT2" ]; then
+    echo "Unusual bin path concoction $RESULT $RESULT2"
     exit 1
 fi
 


### PR DESCRIPTION
This adds a new environment variable to point to the bin path.  This is useful for custom tool packagers.

We also unified the implementation of shell and custom tool environments in the new Shell.environment function.

There are some minor changes to the custom tool environment that come along with this change, such as running in the directory of the imported package.  To my knowledge, I'm the only one who will notice.
