### PR TITLE
Remove platform hax

### DIFF
--- a/build.atpkg
+++ b/build.atpkg
@@ -17,7 +17,7 @@
 (package
   :name "atbuild"
   :import-packages ["atpkg/build.atpkg"]
-  
+  :version "1.3"
   :tasks {
     :atbuild {
       :tool "atllbuild"
@@ -86,12 +86,18 @@
       :dependencies ["atbin"]
       :recommends "xz-utils"
       :suggests "package-deb"
+      :only-platforms ["linux"]
     }
     :package-osx {
       :tool "package-homebrew.attool"
       :name "atbuild"
       :github-project "AnarchyTools/atbuild"
       :dependencies ["atbin"]
+      :only-platforms ["osx"]
+    }
+    :package {
+      :tool "nop"
+      :dependencies ["package-osx" "package-linux"]
     }
   }
 

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -10,19 +10,11 @@ ATBUILD="`pwd`/.atllbuild/products/atbuild"
 pwd
 
 echo "****************SELF-HOSTING TEST**************"
-export ATBUILD_PACKAGE_VERSION="1.2"
-echo "Remove this line after releasing 1.2"
 
-if [ "$UNAME" == "Darwin" ]; then
-    PLATFORM_SPECIFIC_PACKAGE="package-osx"
-else
-    PLATFORM_SPECIFIC_PACKAGE="package-linux"
-fi
-
-if ! $ATBUILD $PLATFORM_SPECIFIC_PACKAGE --use-overlay static; then
+if ! $ATBUILD package --use-overlay static; then
     echo "Self-host failed; maybe you're not running CaffeinatedSwift?"
     echo "Retrying with non-static build"
-    $ATBUILD $PLATFORM_SPECIFIC_PACKAGE
+    $ATBUILD package
 fi
 
 echo "****************ONLY-PLATFORMS TEST**************"


### PR DESCRIPTION
We enabled some hax to get a self-hosted atbuild on 1.1.  However, since 1.2 is released, these hacks are no longer required.
- Use version field from build.atpkg
- Use only-platforms to segregate linux/osx packaging behavior
- Use `package` noptask as an alias for the platform packager

Resolve #96
