### PR TITLE
Fix WMO

### DIFF
--- a/tests/fixtures/platforms/known-linux-bootstrap.yaml
+++ b/tests/fixtures/platforms/known-linux-bootstrap.yaml
@@ -14,6 +14,8 @@ commands:
      sources: ["main.swift"]
      objects: [".atllbuild/objects/main.swift.o"]
      outputs: ["<atllbuild-swiftc>", ".atllbuild/objects/main.swift.o"]
+     enable-whole-module-optimization: false
+     num-threads: 8
      module-name: platforms
      module-output-path: .atllbuild/products/platforms.swiftmodule
      temps-path: .atllbuild/llbuildtmp

--- a/tests/fixtures/platforms/known-osx-bootstrap.yaml
+++ b/tests/fixtures/platforms/known-osx-bootstrap.yaml
@@ -14,6 +14,8 @@ commands:
      sources: ["main.swift"]
      objects: [".atllbuild/objects/main.swift.o"]
      outputs: ["<atllbuild-swiftc>", ".atllbuild/objects/main.swift.o"]
+     enable-whole-module-optimization: false
+     num-threads: 8
      module-name: platforms
      module-output-path: .atllbuild/products/platforms.swiftmodule
      temps-path: .atllbuild/llbuildtmp

--- a/tests/fixtures/wmo/build.atpkg
+++ b/tests/fixtures/wmo/build.atpkg
@@ -9,6 +9,7 @@
       :output-type "static-library"
       :publish-product true
       :whole-module-optimization true
+      :compile-options ["-O"]
     }
             
   }


### PR DESCRIPTION
We previously used a (pretty bad) hack for WMO.  This resulted in issues like #92.

Upstream now has proper support for WMO (see generally, https://github.com/apple/swift-llbuild/pull/28, https://bugs.swift.org/browse/SR-881).

We now use the upstream feature to handle this case.  We also add -num-threads support, which upstream recently added.

Note that our implementation now only works for swift-DEVELOPMENT-SNAPSHOT-2016-05-09-a and above.

Resolve #92
