### PR TITLE
Remove atllbuild option swiftc-path

### DIFF
--- a/attools/src/atllbuild.swift
+++ b/attools/src/atllbuild.swift
@@ -256,7 +256,6 @@ final class ATllbuild : Tool {
         case LinkSDK = "link-sdk"
         case LinkWithProduct = "link-with-product"
         case LinkWithAtbin = "link-with-atbin"
-        case SwiftCPath = "swiftc-path"
         case XCTestify = "xctestify"
         case XCTestStrict = "xctest-strict"
 		case IncludeWithUser = "include-with-user"
@@ -282,8 +281,7 @@ final class ATllbuild : Tool {
                 LinkOptions,
                 LinkSDK,
                 LinkWithProduct,
-                LinkWithAtbin,
-                SwiftCPath,
+				LinkWithAtbin,
                 XCTestify,
                 XCTestStrict,
 				IncludeWithUser,
@@ -616,15 +614,7 @@ final class ATllbuild : Tool {
         else {
             llbuildyamlpath = workDirectory.appending("llbuild.yaml")
         }
-        let swiftCPath: Path
-        if let c = task[Options.SwiftCPath.rawValue]?.string {
-            print("Warning: \(Options.SwiftCPath.rawValue) is deprecated and will be removed in a future release of atbuild.  Use --toolchain to specify a different toolchain, or --platform when bootstrapping to a different platform.")
-            sleep(5)
-            swiftCPath = Path(c)
-        }
-        else {
-            swiftCPath = findToolPath(toolName: "swiftc", toolchain: toolchain)
-        }
+        let swiftCPath = findToolPath(toolName: "swiftc", toolchain: toolchain)
 
         let enableWMO: Bool
         if let wmo = task[Options.WholeModuleOptimization.rawValue]?.bool {

--- a/build.atpkg
+++ b/build.atpkg
@@ -35,7 +35,6 @@
         }
         :bootstrap-linux {
           :bootstrap-only true
-          :swiftc-path "/usr/local/bin/swiftc"
           :link-sdk false
           :llbuildyaml "bootstrap/bootstrap-linux.swift-build"
         }
@@ -59,7 +58,6 @@
         }
         :bootstrap-linux {
           :bootstrap-only true
-          :swiftc-path "/usr/local/bin/swiftc"
           :link-sdk false
           :llbuildyaml "bootstrap/bootstrap-linux-attools.swift-build"
         }


### PR DESCRIPTION
This option was deprecated in atbuild 0.9.0.  Use `--toolchain` on the CLI instead.

Users should have had enough time to migrate at this point.
