### PR TITLE
Add actual effects to the configurations

### DIFF
--- a/attools/src/Configuration.swift
+++ b/attools/src/Configuration.swift
@@ -13,6 +13,15 @@
 // limitations under the License.
 
 public enum Configuration  {
+
+    public enum DebugInstrumentationType {
+        ///Instrumentation should be included in the target
+        case Included
+        ///No instrumentation for the target
+        case Omitted
+        ///Instumentation should be generated separately, e.g. DWARF
+        case Stripped
+    }
     ///Built-in configurations
 
     ///The default configuration.
@@ -103,6 +112,15 @@ extension Configuration {
             case .Debug, .Release, .Benchmark, .Test: return false
             case .None: return true
             case .User: return nil
+        }
+    }
+
+    ///Whether debug instrumentation 
+    var debugInstrumentation: DebugInstrumentationType {
+        switch(self) {
+            case .Debug, .Test: return .Included
+            case .Release, .Benchmark: return .Stripped
+            case .User, .None: return .Omitted
         }
     }
 }

--- a/attools/src/PackageAtbin.swift
+++ b/attools/src/PackageAtbin.swift
@@ -176,9 +176,13 @@ class PackageAtbin:Tool {
             let cmd: String
             switch Platform.hostPlatform {
                 case .OSX:
-                cmd = "tar c --options \"xz:compression-level=9\" -Jf \(tarxz) bin/\(name).atbin -C bin"
+                let fc = currentConfiguration.fastCompile == true
+                let compressionLevel = fc ? "0" :"9"
+                cmd = "tar c --options \"xz:compression-level=\(compressionLevel)\" -Jf \(tarxz) bin/\(name).atbin -C bin"
                 case .Linux:
-                cmd = "XZ_OPT=-8 tar cJf \(tarxz) bin/\(name).atbin -C bin"
+                let fc = currentConfiguration.fastCompile == true
+                let compressionLevel = fc ? "0" :"8"
+                cmd = "XZ_OPT=-\(compressionLevel) tar cJf \(tarxz) bin/\(name).atbin -C bin"
                 default:
                 fatalError("Unsupported host platform \(Platform.hostPlatform)")
             }

--- a/attools/src/Shell.swift
+++ b/attools/src/Shell.swift
@@ -54,6 +54,19 @@ final class Shell : Tool {
             mysetEnv("ATBUILD_CONFIGURATION_NO_MAGIC", o ? "1":"0")
         }
 
+        //expose debug configuration info
+        let conf: String
+        switch (currentConfiguration.debugInstrumentation) {
+            case .Included:
+            conf = "included"
+            case .Omitted:
+            conf = "omitted"
+            case .Stripped:
+            conf = "stripped"
+        }
+        mysetEnv("ATBUILD_CONFIGURATION_DEBUG_INSTRUMENTATION", conf)
+
+
         //does bin path not exist?
         //let's create it!
         let binPath = try! FS.getWorkingDirectory().appending("bin")

--- a/attools/src/atllbuild.swift
+++ b/attools/src/atllbuild.swift
@@ -620,9 +620,7 @@ final class ATllbuild : Tool {
         var enableWMO: Bool
         if let wmo = task[Options.WholeModuleOptimization.rawValue]?.bool {
             enableWMO = wmo
-            print("wmo is deprecated.  Please use --configuration release instead.")
-            print("If you aren't able to migrate to --configuration, please file a bug with your usecase at https://github.com/AnarchyTools/atbuild/issues")
-            sleep(5)
+            //we can't deprecate WMO due to a bug in swift-preview-1 that prevents it from being useable in some cases on Linux
         }
         else { enableWMO = false }
 
@@ -640,7 +638,14 @@ final class ATllbuild : Tool {
 
         if currentConfiguration.optimize == true {
             compileOptions.append("-O")
-            enableWMO = true
+            switch(Platform.buildPlatform) {
+                case .Linux:
+                //don't enable WMO on Linux
+                //due to bug in swift-preview-1
+                break
+                default:
+                enableWMO = true
+            }
         }
         if task[Options.Magic.rawValue] != nil {
             print("Warning: Magic is deprecated.  Please migrate to --configuration none.  If --configuration none won't work for your usecase, file a bug at https://github.com/AnarchyTools/atbuild/issues")

--- a/tests/fixtures/configurations/build.atpkg
+++ b/tests/fixtures/configurations/build.atpkg
@@ -17,5 +17,13 @@
                 }
             }
         }
+
+        :build {
+            :tool "atllbuild"
+            :sources ["src/**.swift"]
+            :name "conftest"
+            :output-type "executable"
+            :publish-product true
+        }
      }
 )

--- a/tests/fixtures/configurations/src/main.swift
+++ b/tests/fixtures/configurations/src/main.swift
@@ -1,0 +1,11 @@
+#if ATBUILD_DEBUG
+print("Debug build")
+#elseif ATBUILD_RELEASE
+print("Release build")
+#elseif ATBUILD_TEST
+print("Test build")
+#elseif ATBUILD_BENCH
+print("Bench build")
+#elseif ATBUILD_JAMES_BOND
+print("James bond build")
+#endif

--- a/tests/fixtures/platforms/known-linux-bootstrap.yaml
+++ b/tests/fixtures/platforms/known-linux-bootstrap.yaml
@@ -19,7 +19,7 @@ commands:
      module-name: platforms
      module-output-path: .atllbuild/products/platforms.swiftmodule
      temps-path: .atllbuild/llbuildtmp
-     other-args: ["-j8", "-D", "ATBUILD", "-I", ".atllbuild/products/", "-D", "LINUX"]
+     other-args: ["-j8", "-D", "ATBUILD", "-I", ".atllbuild/products/", "-D", "LINUX", "-g", "-DATBUILD_DEBUG"]
   <atllbuild>:
     tool: shell
     inputs: ["<atllbuild-swiftc>", ".atllbuild/objects/main.swift.o"]

--- a/tests/fixtures/platforms/known-osx-bootstrap.yaml
+++ b/tests/fixtures/platforms/known-osx-bootstrap.yaml
@@ -19,10 +19,10 @@ commands:
      module-name: platforms
      module-output-path: .atllbuild/products/platforms.swiftmodule
      temps-path: .atllbuild/llbuildtmp
-     other-args: ["-j8", "-D", "ATBUILD", "-I", ".atllbuild/products/", "-sdk", "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk", "-D", "OSX"]
+     other-args: ["-j8", "-D", "ATBUILD", "-I", ".atllbuild/products/", "-sdk", "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk", "-D", "OSX", "-g", "-DATBUILD_DEBUG"]
   <atllbuild>:
     tool: shell
     inputs: ["<atllbuild-swiftc>", ".atllbuild/objects/main.swift.o"]
     outputs: ["<atllbuild>", ".atllbuild/products/platforms"]
-    args: ["/Library/Developer/Toolchains/swift-latest.xctoolchain/usr/bin/swiftc", "-o", ".atllbuild/products/platforms", ".atllbuild/objects/main.swift.o", "-Xlinker", "-dead_strip"]
+    args: ["/Library/Developer/Toolchains/swift-latest.xctoolchain/usr/bin/swiftc", "-o", ".atllbuild/products/platforms", ".atllbuild/objects/main.swift.o"]
     description: Linking executable .atllbuild/products/platforms

--- a/tests/fixtures/wmo/build.atpkg
+++ b/tests/fixtures/wmo/build.atpkg
@@ -8,8 +8,6 @@
       :name "wmo"
       :output-type "static-library"
       :publish-product true
-      :whole-module-optimization true
-      :compile-options ["-O"]
     }
             
   }

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -11,11 +11,7 @@ pwd
 
 echo "****************SELF-HOSTING TEST**************"
 
-if ! $ATBUILD package --use-overlay static; then
-    echo "Self-host failed; maybe you're not running CaffeinatedSwift?"
-    echo "Retrying with non-static build"
-    $ATBUILD package
-fi
+$ATBUILD atbuild
 
 echo "****************CONFIGURATION TEST**************"
 
@@ -34,6 +30,42 @@ fi
 
 $ATBUILD --configuration custom tool > /tmp/configurations.txt
 if ! grep "\-always some flag --bond james bond" /tmp/configurations.txt; then
+    echo "Invalid configuration behavior"
+    exit 1
+fi
+
+## try atllbuild-level config
+$ATBUILD --configuration debug build
+bin/conftest > /tmp/configurations.txt
+if ! grep "Debug build" /tmp/configurations.txt; then
+    echo "Invalid configuration behavior"
+    exit 1
+fi
+
+$ATBUILD --configuration release build
+bin/conftest > /tmp/configurations.txt
+if ! grep "Release build" /tmp/configurations.txt; then
+    echo "Invalid configuration behavior"
+    exit 1
+fi
+
+$ATBUILD --configuration test build
+bin/conftest > /tmp/configurations.txt
+if ! grep "Test build" /tmp/configurations.txt; then
+    echo "Invalid configuration behavior"
+    exit 1
+fi
+
+$ATBUILD --configuration bench build
+bin/conftest > /tmp/configurations.txt
+if ! grep "Bench build" /tmp/configurations.txt; then
+    echo "Invalid configuration behavior"
+    exit 1
+fi
+
+$ATBUILD --configuration JAMES_BOND build
+bin/conftest > /tmp/configurations.txt
+if ! grep "James bond build" /tmp/configurations.txt; then
     echo "Invalid configuration behavior"
     exit 1
 fi
@@ -403,7 +435,7 @@ $ATBUILD
 
 echo "****************WMO TEST**************"
 cd $DIR/tests/fixtures/wmo
-$ATBUILD
+$ATBUILD --configuration release
 
 echo "****************UMBRELLA TEST**************"
 cd $DIR/tests/fixtures/umbrella_header
@@ -542,4 +574,15 @@ if $ATBUILD --use-overlay foo; then
     exit 1
 fi
 
-printf "\e[1m\e[32m***ATBUILD TEST SCRIPT PASSED SUCCESSFULLY*****\e[0m"
+printf "\e[1m\e[32m***ATBUILD TESTS PASSED SUCCESSFULLY*****\e[0m\n"
+
+echo "*****************PACKAGING**********************"
+cd $DIR
+if ! $ATBUILD package --use-overlay static --configuration release;  then
+    echo "Self-host failed; maybe you're not running CaffeinatedSwift?"
+    echo "Retrying with non-static build"
+    $ATBUILD package --configuration release
+fi
+
+
+printf "\e[1m\e[32m***ATBUILD BUILT SUCCESSFULLY*****\e[0m\n"


### PR DESCRIPTION
This extends #104 by adding actual effects to the configurations rather than have them be no-ops.

Effects include:
- debug instrumentation (new in this PR), for emitting `-g` (see #73 for an obvious extension)
- optimization control / WMO control
- compression level (faster debug atbins)
- test instrumentation (`-enable-testing`)
- `#if ATBUILD_RELEASE` etc. from Swift code

There are some deprecations associated with this PR:
- `magic` atllbuild option is now deprecated; to opt out of magic use `--configuration none` instead.
- `whole-module-optimization` will be deprecated soon but isn't deprecated in this PR

Doc PR to follow.

In addition, CI is now updated to produce release (optimized) builds for atbuild, which significantly optimizes atbuild performance.
