### PR TITLE
Support Xcode 8 GM

### DIFF
--- a/bootstrap/bootstrap-macosx-atfoundation.swift-build
+++ b/bootstrap/bootstrap-macosx-atfoundation.swift-build
@@ -20,7 +20,7 @@ commands:
      module-name: atfoundation
      module-output-path: .atllbuild/products/atfoundation.swiftmodule
      temps-path: .atllbuild/llbuildtmp
-     other-args: ["-j8", "-D", "ATBUILD", "-I", ".atllbuild/products/", "-sdk", "/Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/", "-enable-testing", "-g", "-Xcc", "-D_GNU_SOURCE", "-g", "-DATBUILD_DEBUG"]
+     other-args: ["-j8", "-D", "ATBUILD", "-I", ".atllbuild/products/", "-sdk", "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk", "-enable-testing", "-g", "-Xcc", "-D_GNU_SOURCE", "-g", "-DATBUILD_DEBUG"]
   <atllbuild>:
     tool: shell
     inputs: ["<atllbuild-swiftc>", ".atllbuild/objects/charset.swift.o", ".atllbuild/objects/date.swift.o", ".atllbuild/objects/timeinterval.swift.o", ".atllbuild/objects/file.swift.o", ".atllbuild/objects/fileinfo.swift.o", ".atllbuild/objects/fs.swift.o", ".atllbuild/objects/path.swift.o", ".atllbuild/objects/logger.swift.o", ".atllbuild/objects/replace.swift.o", ".atllbuild/objects/search.swift.o", ".atllbuild/objects/split.swift.o", ".atllbuild/objects/substring.swift.o", ".atllbuild/objects/whitespace.swift.o", ".atllbuild/objects/string.swift.o", ".atllbuild/objects/syserror.swift.o", ".atllbuild/objects/tools.swift.o", ".atllbuild/objects/url.swift.o"]

--- a/bootstrap/bootstrap-macosx-atpkg.swift-build
+++ b/bootstrap/bootstrap-macosx-atpkg.swift-build
@@ -20,7 +20,7 @@ commands:
      module-name: atpkg
      module-output-path: .atllbuild/products/atpkg.swiftmodule
      temps-path: .atllbuild/llbuildtmp
-     other-args: ["-j8", "-D", "ATBUILD", "-I", ".atllbuild/products/", "-sdk", "/Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/", "-g", "-DATBUILD_DEBUG"]
+     other-args: ["-j8", "-D", "ATBUILD", "-I", ".atllbuild/products/", "-sdk", "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk", "-g", "-DATBUILD_DEBUG"]
   <atllbuild>:
     tool: shell
     inputs: ["<atllbuild-swiftc>", ".atllbuild/objects/Binary.swift.o", ".atllbuild/objects/CollectSources.swift.o", ".atllbuild/objects/ExternalDependency.swift.o", ".atllbuild/objects/Package.swift.o", ".atllbuild/objects/Parser.swift.o", ".atllbuild/objects/Scanner.swift.o", ".atllbuild/objects/Tokenization.swift.o", ".atllbuild/objects/Substitutions.swift.o", ".atllbuild/objects/Task.swift.o"]

--- a/bootstrap/bootstrap-macosx-attools.swift-build
+++ b/bootstrap/bootstrap-macosx-attools.swift-build
@@ -20,7 +20,7 @@ commands:
      module-name: attools
      module-output-path: .atllbuild/products/attools.swiftmodule
      temps-path: .atllbuild/llbuildtmp
-     other-args: ["-j8", "-D", "ATBUILD", "-I", ".atllbuild/products/", "-sdk", "/Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/", "-g", "-DATBUILD_DEBUG"]
+     other-args: ["-j8", "-D", "ATBUILD", "-I", ".atllbuild/products/", "-sdk", "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk", "-g", "-DATBUILD_DEBUG"]
   <atllbuild>:
     tool: shell
     inputs: ["<atllbuild-swiftc>", ".atllbuild/objects/atllbuild.swift.o", ".atllbuild/objects/Configuration.swift.o", ".atllbuild/objects/CustomTool.swift.o", ".atllbuild/objects/Nop.swift.o", ".atllbuild/objects/PackageAtbin.swift.o", ".atllbuild/objects/PackageFramework.swift.o", ".atllbuild/objects/PlatformPaths.swift.o", ".atllbuild/objects/Shell.swift.o", ".atllbuild/objects/TaskRunner.swift.o", ".atllbuild/objects/Tools.swift.o", ".atllbuild/objects/XCTestRun.swift.o"]

--- a/bootstrap/bootstrap-macosx.swift-build
+++ b/bootstrap/bootstrap-macosx.swift-build
@@ -19,7 +19,7 @@ commands:
      module-name: atbuild
      module-output-path: .atllbuild/products/atbuild.swiftmodule
      temps-path: .atllbuild/llbuildtmp
-     other-args: ["-j8", "-D", "ATBUILD", "-I", ".atllbuild/products/", "-sdk", "/Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/", "-g", "-DATBUILD_DEBUG"]
+     other-args: ["-j8", "-D", "ATBUILD", "-I", ".atllbuild/products/", "-sdk", "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk", "-g", "-DATBUILD_DEBUG"]
   <atllbuild>:
     tool: shell
     inputs: ["<atllbuild-swiftc>", ".atllbuild/objects/main.swift.o", ".atllbuild/products/attools.a", ".atllbuild/products/atpkg.a", ".atllbuild/products/atfoundation.a"]

--- a/build.atpkg
+++ b/build.atpkg
@@ -72,7 +72,7 @@
 
     :bootstrap {
       :tool "shell"
-      :script "atbuild atbuild --use-overlay bootstrap-linux --platform linux && atbuild atbuild --use-overlay bootstrap-osx --platform osx" 
+      :script "bin/atbuild atbuild --use-overlay bootstrap-linux --platform linux && bin/atbuild atbuild --use-overlay bootstrap-osx --platform osx" 
     }
 
     :atbin {

--- a/tests/fixtures/platforms/known-osx-bootstrap.yaml
+++ b/tests/fixtures/platforms/known-osx-bootstrap.yaml
@@ -19,7 +19,7 @@ commands:
      module-name: platforms
      module-output-path: .atllbuild/products/platforms.swiftmodule
      temps-path: .atllbuild/llbuildtmp
-     other-args: ["-j8", "-D", "ATBUILD", "-I", ".atllbuild/products/", "-sdk", "/Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk", "-D", "OSX", "-g", "-DATBUILD_DEBUG"]
+     other-args: ["-j8", "-D", "ATBUILD", "-I", ".atllbuild/products/", "-sdk", "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk", "-D", "OSX", "-g", "-DATBUILD_DEBUG"]
   <atllbuild>:
     tool: shell
     inputs: ["<atllbuild-swiftc>", ".atllbuild/objects/main.swift.o"]

--- a/tests/fixtures/xcode_toolchain/build.atpkg
+++ b/tests/fixtures/xcode_toolchain/build.atpkg
@@ -2,13 +2,6 @@
   :name "xcode_toolchain"
   
   :tasks {
-    :default {
-      :tool "atllbuild"
-      :sources ["test.swift"]
-      :name "hello"
-      :output-type "executable"
-      :publish-product true
-    }   
     :swiftthree {
       :tool "atllbuild"
       :sources ["test-3.swift"]

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -415,16 +415,9 @@ echo "****************XCODE TOOLCHAIN TEST**************"
 
 if [ -e "/Applications/Xcode.app" ]; then
     cd $DIR/tests/fixtures/xcode_toolchain
-    $ATBUILD --toolchain xcode
+    $ATBUILD swiftthree --toolchain xcode
 else
-    echo "Xcode is not installed; skipping test"
-fi
-
-if [ -e "/Applications/Xcode-beta.app" ]; then
-    cd $DIR/tests/fixtures/xcode_toolchain
-    $ATBUILD swiftthree --toolchain xcode-beta
-else
-    echo "Xcode beta toolchain is not installed; skipping test"
+    echo "Xcode toolchain is not installed; skipping test"
 fi
 
 echo "****************PACKAGE FRAMEWORK TESTS**************"


### PR DESCRIPTION
- Drop test coverage for Xcode 7 since it's likely not installed
- We now pull paths from xcode-select when we don't specify a toolchain which is saner than using hardcoded paths
- We now more robustly test if a given toolchain is from xcode 7 or not rather than rely on the filename
- Bootstrap for Xcode 8 installed to Xcode.app
